### PR TITLE
full replace systemd-resolved by dnsmasq

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,6 +1,11 @@
-- name: "systemd-resolved fix"
-  lineinfile: "dest=/etc/systemd/resolved.conf regexp='^DNS=127.0.0.1' line='DNS=127.0.0.1' state=present"
-  notify: "restart systemd-resolved"
+- name: Make DNS lookup
+  template:
+    src: resolv.conf
+    dest: "/etc/resolv.conf"
+
+- name: Disable systemd-resolved
+  become: yes
+  command: systemctl disable systemd-resolved.service
 
 - meta: flush_handlers
 

--- a/roles/network/templates/main.conf
+++ b/roles/network/templates/main.conf
@@ -1,6 +1,6 @@
 listen-address=127.0.0.1
 bind-interfaces
-#no-resolv
+no-resolv
 server=8.8.8.8
 server=8.8.4.4
 server=1.1.1.1

--- a/roles/network/templates/resolv.conf
+++ b/roles/network/templates/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 127.0.0.1


### PR DESCRIPTION
- force replace file `/etc/resolv.conf` from template
- disable `systemd-resolved`
- enable `no-resolv` option in dnsmasq's `main.conf`